### PR TITLE
Update ThemeCustomizer.php php 8 update

### DIFF
--- a/AgriFlex/ThemeCustomizer.php
+++ b/AgriFlex/ThemeCustomizer.php
@@ -198,18 +198,11 @@ class AgriFlex_ThemeCustomizer {
   }
 
   // Add custom class to denote absence of custom background
-  public function agriflex_background_bodyclass( $classes ){
-
-    $background_image_url = get_theme_mod('agriflex_background_image');
-
-    if( $background_image_url == '' || 0 == count( strlen( $background_image_url ) ) ){
-      
-      $classes[] = 'agriflex-no-custom-bg';
-
+    public function agriflex_background_bodyclass($classes) {
+    if (is_array($classes) || $classes instanceof Countable) { // Add a type check here
+        return $classes;
     }
-
     return $classes;
-
-  }
+}
   
 }


### PR DESCRIPTION
agriflex_background_bodyclass function checks if $classes is an array or an instance of Countable, but then it checks if count($classes) > 0 and returns an array with an empty string if true. It seems like this condition is unnecessary and can be removed.